### PR TITLE
Fixed RAII memory management in ConvertibleBuffer and ConvertibleBufferReturn

### DIFF
--- a/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBuffer.hpp
+++ b/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBuffer.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <span>
+#include <vector>
 
 
 
@@ -17,16 +18,18 @@ struct ConvertibleBuffer final {
 	struct ::buffer buffer {};
 	ConvertibleBuffer() = default;
 	ConvertibleBuffer(struct ::buffer buff) : buffer(buff) {}
-	
+
 	std::span<const uint8_t> serialize() const {
 		return std::span {reinterpret_cast<const uint8_t *>(buffer.data), buffer.size_in_bytes};
 	}
 	void deserialize(std::span<const uint8_t> bytes) {
-		auto size = bytes.size();
-		buffer.data = new uint8_t[size];
-		buffer.size_in_bytes = size;
-		std::memcpy(buffer.data, bytes.data(), size);
+		data_.assign(bytes.begin(), bytes.end());
+		buffer.data = data_.data();
+		buffer.size_in_bytes = data_.size();
 	}
+
+private:
+	std::vector<uint8_t> data_ {};
 };
 
 }

--- a/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBuffer.hpp
+++ b/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBuffer.hpp
@@ -17,7 +17,47 @@ namespace bringauto::fleet_protocol::async_function_execution_definitions {
 struct ConvertibleBuffer final {
 	struct ::buffer buffer {};
 	ConvertibleBuffer() = default;
-	ConvertibleBuffer(struct ::buffer buff) : buffer(buff) {}
+	explicit ConvertibleBuffer(struct ::buffer buff) : buffer(buff) {}
+
+	ConvertibleBuffer(const ConvertibleBuffer& other) : buffer(other.buffer), data_(other.data_) {
+		if(!data_.empty()) {
+			buffer.data = data_.data();
+			buffer.size_in_bytes = data_.size();
+		}
+	}
+	ConvertibleBuffer& operator=(const ConvertibleBuffer& other) {
+		if(this != &other) {
+			buffer = other.buffer;
+			data_ = other.data_;
+			if(!data_.empty()) {
+				buffer.data = data_.data();
+				buffer.size_in_bytes = data_.size();
+			}
+		}
+		return *this;
+	}
+	ConvertibleBuffer(ConvertibleBuffer&& other) noexcept : buffer(other.buffer), data_(std::move(other.data_)) {
+		if(!data_.empty()) {
+			buffer.data = data_.data();
+			buffer.size_in_bytes = data_.size();
+		}
+		other.buffer.data = nullptr;
+		other.buffer.size_in_bytes = 0;
+	}
+	ConvertibleBuffer& operator=(ConvertibleBuffer&& other) noexcept {
+		if(this != &other) {
+			buffer = other.buffer;
+			data_ = std::move(other.data_);
+			if(!data_.empty()) {
+				buffer.data = data_.data();
+				buffer.size_in_bytes = data_.size();
+			}
+			other.buffer.data = nullptr;
+			other.buffer.size_in_bytes = 0;
+		}
+		return *this;
+	}
+	~ConvertibleBuffer() = default;
 
 	std::span<const uint8_t> serialize() const {
 		return std::span {reinterpret_cast<const uint8_t *>(buffer.data), buffer.size_in_bytes};

--- a/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBuffer.hpp
+++ b/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBuffer.hpp
@@ -11,20 +11,37 @@
 namespace bringauto::fleet_protocol::async_function_execution_definitions {
 
 /**
- * @brief ConvertibleBuffer is a helper class to convert a fleet_protocol 'buffer' struct
- * to/from a byte span for serialization/deserialization.
+ * @brief ConvertibleBuffer is a RAII wrapper around the fleet_protocol 'buffer' struct
+ * that manages the lifetime of the buffer data and supports conversion to/from a byte span.
+ * Buffer data ownership is maintained internally via a std::vector; buffer.data always
+ * points into that internal storage after deserialization.
  */
 struct ConvertibleBuffer final {
+	/**
+	 * @brief The wrapped fleet_protocol buffer struct.
+	 */
 	struct ::buffer buffer {};
+	/**
+	 * @brief Default constructor. Creates an empty buffer.
+	 */
 	ConvertibleBuffer() = default;
+	/**
+	 * @brief Constructs from an existing ::buffer. Does not take ownership of buff.data.
+	 */
 	explicit ConvertibleBuffer(struct ::buffer buff) : buffer(buff) {}
 
+	/**
+	 * @brief Copy constructor. Rebinds buffer.data to the copied internal storage.
+	 */
 	ConvertibleBuffer(const ConvertibleBuffer& other) : buffer(other.buffer), data_(other.data_) {
 		if(!data_.empty()) {
 			buffer.data = data_.data();
 			buffer.size_in_bytes = data_.size();
 		}
 	}
+	/**
+	 * @brief Copy assignment operator. Rebinds buffer.data to the copied internal storage.
+	 */
 	ConvertibleBuffer& operator=(const ConvertibleBuffer& other) {
 		if(this != &other) {
 			buffer = other.buffer;
@@ -36,6 +53,9 @@ struct ConvertibleBuffer final {
 		}
 		return *this;
 	}
+	/**
+	 * @brief Move constructor. Rebinds buffer.data to the moved-in internal storage.
+	 */
 	ConvertibleBuffer(ConvertibleBuffer&& other) noexcept : buffer(other.buffer), data_(std::move(other.data_)) {
 		if(!data_.empty()) {
 			buffer.data = data_.data();
@@ -44,6 +64,9 @@ struct ConvertibleBuffer final {
 		other.buffer.data = nullptr;
 		other.buffer.size_in_bytes = 0;
 	}
+	/**
+	 * @brief Move assignment operator. Rebinds buffer.data to the moved-in internal storage.
+	 */
 	ConvertibleBuffer& operator=(ConvertibleBuffer&& other) noexcept {
 		if(this != &other) {
 			buffer = other.buffer;
@@ -57,11 +80,20 @@ struct ConvertibleBuffer final {
 		}
 		return *this;
 	}
+	/**
+	 * @brief Destructor.
+	 */
 	~ConvertibleBuffer() = default;
 
+	/**
+	 * @brief Returns a view of the buffer data as a byte span. Does not copy.
+	 */
 	std::span<const uint8_t> serialize() const {
 		return std::span {reinterpret_cast<const uint8_t *>(buffer.data), buffer.size_in_bytes};
 	}
+	/**
+	 * @brief Copies bytes into internal storage and rebinds buffer.data to it.
+	 */
 	void deserialize(std::span<const uint8_t> bytes) {
 		data_.assign(bytes.begin(), bytes.end());
 		buffer.data = data_.data();

--- a/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
+++ b/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
@@ -14,14 +14,29 @@ namespace bringauto::fleet_protocol::async_function_execution_definitions {
 /**
  * @brief ConvertibleBufferReturn is a helper class to convert a fleet_protocol 'buffer' struct
  * and a return code to/from a byte span for serialization/deserialization.
- * The first 4 bytes represent the return code (int), followed by the buffer data.
+ * The first 4 bytes represent the return code (std::int32_t), followed by the buffer data.
  */
 struct ConvertibleBufferReturn final {
-	int returnCode {};
+	/**
+	 * @brief The return code associated with the buffer.
+	 */
+	std::int32_t returnCode {};
+	/**
+	 * @brief The wrapped fleet_protocol buffer struct.
+	 */
 	struct ::buffer buffer {};
+	/**
+	 * @brief Default constructor. Creates an empty buffer with return code 0.
+	 */
 	ConvertibleBufferReturn() = default;
-	ConvertibleBufferReturn(int code, struct ::buffer buff) : returnCode(code), buffer(buff) {}
+	/**
+	 * @brief Constructs from a return code and an existing ::buffer. Does not take ownership of buff.data.
+	 */
+	ConvertibleBufferReturn(std::int32_t code, struct ::buffer buff) : returnCode(code), buffer(buff) {}
 
+	/**
+	 * @brief Copy constructor. Rebinds buffer.data to the copied internal storage.
+	 */
 	ConvertibleBufferReturn(const ConvertibleBufferReturn& other)
 		: returnCode(other.returnCode), buffer(other.buffer),
 		  serialized_(other.serialized_), data_(other.data_) {
@@ -30,6 +45,9 @@ struct ConvertibleBufferReturn final {
 			buffer.size_in_bytes = data_.size();
 		}
 	}
+	/**
+	 * @brief Copy assignment operator. Rebinds buffer.data to the copied internal storage.
+	 */
 	ConvertibleBufferReturn& operator=(const ConvertibleBufferReturn& other) {
 		if(this != &other) {
 			returnCode = other.returnCode;
@@ -43,6 +61,9 @@ struct ConvertibleBufferReturn final {
 		}
 		return *this;
 	}
+	/**
+	 * @brief Move constructor. Rebinds buffer.data to the moved-in internal storage.
+	 */
 	ConvertibleBufferReturn(ConvertibleBufferReturn&& other) noexcept
 		: returnCode(other.returnCode), buffer(other.buffer),
 		  serialized_(std::move(other.serialized_)), data_(std::move(other.data_)) {
@@ -53,6 +74,9 @@ struct ConvertibleBufferReturn final {
 		other.buffer.data = nullptr;
 		other.buffer.size_in_bytes = 0;
 	}
+	/**
+	 * @brief Move assignment operator. Rebinds buffer.data to the moved-in internal storage.
+	 */
 	ConvertibleBufferReturn& operator=(ConvertibleBufferReturn&& other) noexcept {
 		if(this != &other) {
 			returnCode = other.returnCode;
@@ -68,26 +92,37 @@ struct ConvertibleBufferReturn final {
 		}
 		return *this;
 	}
+	/**
+	 * @brief Destructor.
+	 */
 	~ConvertibleBufferReturn() = default;
 
+	/**
+	 * @brief Serializes returnCode and buffer data into a contiguous byte span.
+	 * The first 4 bytes are the return code in native byte order, followed by buffer data.
+	 */
 	std::span<const uint8_t> serialize() const {
-		serialized_.resize(sizeof(int) + buffer.size_in_bytes);
-		std::memcpy(serialized_.data(), &returnCode, sizeof(int));
+		serialized_.resize(sizeof(std::int32_t) + buffer.size_in_bytes);
+		std::memcpy(serialized_.data(), &returnCode, sizeof(std::int32_t));
 		if(buffer.size_in_bytes > 0) {
-			std::memcpy(serialized_.data() + sizeof(int), buffer.data, buffer.size_in_bytes);
+			std::memcpy(serialized_.data() + sizeof(std::int32_t), buffer.data, buffer.size_in_bytes);
 		}
 		return serialized_;
 	}
+	/**
+	 * @brief Deserializes a byte span into returnCode and buffer data.
+	 * Resets to empty state if bytes is smaller than sizeof(std::int32_t).
+	 */
 	void deserialize(std::span<const uint8_t> bytes) {
-		if(bytes.size() < sizeof(int)) {
+		if(bytes.size() < sizeof(std::int32_t)) {
 			returnCode = 0;
 			data_.clear();
 			buffer.data = nullptr;
 			buffer.size_in_bytes = 0;
 			return;
 		}
-		std::memcpy(&returnCode, bytes.data(), sizeof(int));
-		auto payload = bytes.subspan(sizeof(int));
+		std::memcpy(&returnCode, bytes.data(), sizeof(std::int32_t));
+		auto payload = bytes.subspan(sizeof(std::int32_t));
 		data_.assign(payload.begin(), payload.end());
 		buffer.data = data_.data();
 		buffer.size_in_bytes = data_.size();

--- a/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
+++ b/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <span>
+#include <vector>
 
 
 
@@ -22,21 +23,25 @@ struct ConvertibleBufferReturn final {
 	ConvertibleBufferReturn(int code, struct ::buffer buff) : returnCode(code), buffer(buff) {}
 
 	std::span<const uint8_t> serialize() const {
-		size_t total_size = sizeof(int) + buffer.size_in_bytes;
-		uint8_t* data = new uint8_t[total_size];
-		std::memcpy(data, &returnCode, sizeof(int));
-		std::memcpy(data + sizeof(int), buffer.data, buffer.size_in_bytes);
-		return {data, total_size};
+		serialized_.resize(sizeof(int) + buffer.size_in_bytes);
+		std::memcpy(serialized_.data(), &returnCode, sizeof(int));
+		if(buffer.size_in_bytes > 0) {
+			std::memcpy(serialized_.data() + sizeof(int), buffer.data, buffer.size_in_bytes);
+		}
+		return serialized_;
 	}
 	void deserialize(std::span<const uint8_t> bytes) {
-		auto size = bytes.size();
-		if (size < sizeof(int)) return;
+		if(bytes.size() < sizeof(int)) { return; }
 		std::memcpy(&returnCode, bytes.data(), sizeof(int));
-		size -= sizeof(int);
-		buffer.data = new uint8_t[size];
-		buffer.size_in_bytes = size;
-		std::memcpy(buffer.data, bytes.data() + sizeof(int), size);
+		auto payload = bytes.subspan(sizeof(int));
+		data_.assign(payload.begin(), payload.end());
+		buffer.data = data_.data();
+		buffer.size_in_bytes = data_.size();
 	}
+
+private:
+	mutable std::vector<uint8_t> serialized_ {};
+	std::vector<uint8_t> data_ {};
 };
 
 }

--- a/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
+++ b/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
@@ -31,7 +31,13 @@ struct ConvertibleBufferReturn final {
 		return serialized_;
 	}
 	void deserialize(std::span<const uint8_t> bytes) {
-		if(bytes.size() < sizeof(int)) { return; }
+		if(bytes.size() < sizeof(int)) {
+			returnCode = 0;
+			data_.clear();
+			buffer.data = nullptr;
+			buffer.size_in_bytes = 0;
+			return;
+		}
 		std::memcpy(&returnCode, bytes.data(), sizeof(int));
 		auto payload = bytes.subspan(sizeof(int));
 		data_.assign(payload.begin(), payload.end());

--- a/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
+++ b/include/bringauto/fleet_protocol/async_function_execution_definitions/ConvertibleBufferReturn.hpp
@@ -22,6 +22,54 @@ struct ConvertibleBufferReturn final {
 	ConvertibleBufferReturn() = default;
 	ConvertibleBufferReturn(int code, struct ::buffer buff) : returnCode(code), buffer(buff) {}
 
+	ConvertibleBufferReturn(const ConvertibleBufferReturn& other)
+		: returnCode(other.returnCode), buffer(other.buffer),
+		  serialized_(other.serialized_), data_(other.data_) {
+		if(!data_.empty()) {
+			buffer.data = data_.data();
+			buffer.size_in_bytes = data_.size();
+		}
+	}
+	ConvertibleBufferReturn& operator=(const ConvertibleBufferReturn& other) {
+		if(this != &other) {
+			returnCode = other.returnCode;
+			buffer = other.buffer;
+			serialized_ = other.serialized_;
+			data_ = other.data_;
+			if(!data_.empty()) {
+				buffer.data = data_.data();
+				buffer.size_in_bytes = data_.size();
+			}
+		}
+		return *this;
+	}
+	ConvertibleBufferReturn(ConvertibleBufferReturn&& other) noexcept
+		: returnCode(other.returnCode), buffer(other.buffer),
+		  serialized_(std::move(other.serialized_)), data_(std::move(other.data_)) {
+		if(!data_.empty()) {
+			buffer.data = data_.data();
+			buffer.size_in_bytes = data_.size();
+		}
+		other.buffer.data = nullptr;
+		other.buffer.size_in_bytes = 0;
+	}
+	ConvertibleBufferReturn& operator=(ConvertibleBufferReturn&& other) noexcept {
+		if(this != &other) {
+			returnCode = other.returnCode;
+			buffer = other.buffer;
+			serialized_ = std::move(other.serialized_);
+			data_ = std::move(other.data_);
+			if(!data_.empty()) {
+				buffer.data = data_.data();
+				buffer.size_in_bytes = data_.size();
+			}
+			other.buffer.data = nullptr;
+			other.buffer.size_in_bytes = 0;
+		}
+		return *this;
+	}
+	~ConvertibleBufferReturn() = default;
+
 	std::span<const uint8_t> serialize() const {
 		serialized_.resize(sizeof(int) + buffer.size_in_bytes);
 		std::memcpy(serialized_.data(), &returnCode, sizeof(int));


### PR DESCRIPTION
## Summary
- Replaced raw `new` allocations in `ConvertibleBuffer::deserialize` and `ConvertibleBufferReturn::serialize`/`deserialize` with `std::vector<uint8_t>` for safe RAII memory management
- Eliminates memory leaks caused by allocated buffers never being freed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved buffer ownership and memory management for serialization/deserialization, reducing allocations and improving performance.
  * Added robust copy/move semantics to ensure buffers remain valid after object copies or moves.
* **Bug Fixes**
  * Fixed edge-case deserialization issues and invalid-state handling, improving stability and forward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->